### PR TITLE
Add Nativescript: Progress Next 2019

### DIFF
--- a/conferences/2019/native-script.json
+++ b/conferences/2019/native-script.json
@@ -1,2 +1,13 @@
 [
+{
+  "name": "Progress Next",
+  "url": "https://www.progress.com/next",
+  "startDate": "2019-06-06",
+  "endDate": "2019-06-09",
+  "city": "Orlando",
+  "country": "United States",
+  "cfsUrl": "https://sessionize.com/progressnext-2019/",
+  "cfsStartDate": "2018-08-15",
+  "cfsEndDate": "2019-01-31"
+}
 ]


### PR DESCRIPTION
There is no call for papers (cfp), only a call for speakers (cfs) so I used a different attribute name.
Can we differentiate between these, or should I use cfp attributes, or just leave them out?